### PR TITLE
Feature/message manager support max

### DIFF
--- a/ReplayMessenger.device.lib.nut
+++ b/ReplayMessenger.device.lib.nut
@@ -113,7 +113,7 @@ class ReplayMessenger {
       _beforeReplay[loggerName] <- callback;
     }
 
-    function afterReplay(loggerName, callback = null) {
+    function afterReplay(callback = null, loggerName = "default") {
       _afterReplay[loggerName] <- callback;
     }
 

--- a/ReplayMessenger.device.lib.nut
+++ b/ReplayMessenger.device.lib.nut
@@ -117,12 +117,7 @@ class ReplayMessenger {
       _afterReplay[loggerName] <- callback;
     }
 
-    function setLoggerReadOptions(loggerName, options=null) {
-      if (typeof loggerName == "table" && options == null) { //assume these are the read options provided for the "default" logger
-        options = loggerName;
-        loggerName = "default";
-      }
-
+    function setLoggerReadOptions(options, loggerName = "default") {
       _readOptions[loggerName] <- options;
     }
 

--- a/ReplayMessenger.device.lib.nut
+++ b/ReplayMessenger.device.lib.nut
@@ -109,39 +109,11 @@ class ReplayMessenger {
         return _mm.send(messageName, data, null, _retryInterval, metadata);
     }
 
-    function beforeReplay(loggerName, callback = null) {
-      if (loggerName == null && callback == null) { //assume the user wants to de-register the callback for the "default" logger
-        loggerName = "default";
-      }
-
-      if (typeof loggerName == "string" && callback == null) { //de-register callback
-        if (loggerName in _beforeReplay) delete _beforeReplay[loggerName]
-        return;
-      }
-
-      if (typeof loggerName == "function" && callback == null) { //assume this is the callback provided for "default" logger
-        callback = loggerName;
-        loggerName = "default";
-      }
-
+    function beforeReplay(callback = null, loggerName = "default") {
       _beforeReplay[loggerName] <- callback;
     }
 
     function afterReplay(loggerName, callback = null) {
-      if (loggerName == null && callback == null) { //assume the user wants to de-register the callback for the "default" logger
-        loggerName = "default";
-      }
-
-      if (typeof loggerName == "string" && callback == null) { //de-register callback
-        if (loggerName in _afterReplay) delete _afterReplay[loggerName]
-        return;
-      }
-
-      if (typeof loggerName == "function" && callback == null) { //assume this is the callback provided for "default" logger
-        callback = loggerName;
-        loggerName = "default";
-      }
-
       _afterReplay[loggerName] <- callback;
     }
 


### PR DESCRIPTION
- Added “_readOptions” table that allows a user to define the step/skip
parameters for SPIFlashLogger.read method
- Added onReplayBegin/Complete handlers that allow a user to define
middleware for what happens when replaying data begins and is completed
- Added support for “retryOnInit” option that allowed a user to delay
calling “_scheduleRetryIfConnected” (in case there are several messages
that need to be sent on init — this can be memory intensive)
- Modified _onAck and _onFail so that it only catches messages that
have “loggerName” in the metadata — this assumes that this key being
present means that it was sent through RM (a better option may be to
just use the per-message onAck/onFail handlers)
- Include message metadata in what is saved to SPIFlash — don’t assume
that a user hasn’t included something important here