### PR TITLE
Assume that the last entry in the flash logger has the latest message

### DIFF
--- a/ReplayMessenger.device.lib.nut
+++ b/ReplayMessenger.device.lib.nut
@@ -542,9 +542,8 @@ class ReplayMessenger extends Messenger {
     function _maxMsgId() {
         local maxId = -1;
         local index = 1;
-        local payload = null;
-
-        while (payload = _spiFL.readSync(index++)) {
+        local payload = _spiFL.readSync(-1);
+        if (payload) {
             local id = payload[RM_COMPRESSED_MSG_PAYLOAD]["id"];
             maxId = id > maxId ? id : maxId;
         }


### PR DESCRIPTION
`ReplayMessenger` increments message ID on every `send` command, and writes to the log when necessary. Therefore in the log there can be gaps in message IDs, but the latest log entry should contain the latest saved message.

So it should be safe to take the last entry instead of iterating over all of them. In a rare event of message ID overflow, we actually want to start with the latest one, not with the largest one.

I hope I'm not missing anything that makes the current behavior necessary.



Signed-off-by: Anton Gerasimov <agerasimov@twilio.com>